### PR TITLE
Add page css only if defined

### DIFF
--- a/notion_export_prettify/main.py
+++ b/notion_export_prettify/main.py
@@ -139,16 +139,14 @@ def main():
         # NOTE: this cannot be done as an overlay, due to a bug in PyMuPDF
         if underlay_template := resources.get_resource_content("background.html"):
             green("[PROC] Rendering underlay templates for each page")
-            underlay_html = (
-                HtmlTemplator(underlay_template)
-                .inject(
-                    metadata,
-                    pageNumber="__PAGENUMBER__",
-                    hasCoverPage="hasCoverPage" if with_cover_page else "",
-                )
-                .add_css(page_css)
-                .html
+            underlay_meta_template = HtmlTemplator(underlay_template).inject(
+                metadata,
+                pageNumber="__PAGENUMBER__",
+                hasCoverPage="hasCoverPage" if with_cover_page else "",
             )
+            if page_css:
+                underlay_meta_template.add_css(page_css)
+            underlay_html = underlay_meta_template.html
             pdf_maker.merge_underlay_html(underlay_html)
         else:
             orange(
@@ -168,12 +166,10 @@ def main():
             cover_template = resources.get_resource_content("cover.html")
             if cover_template:
                 green("[PROC] Rendering cover template")
-                cover_html = (
-                    HtmlTemplator(cover_template)
-                    .inject(metadata)
-                    .add_css(page_css)
-                    .html
-                )
+                cover_meta_template = HtmlTemplator(cover_template).inject(metadata)
+                if page_css:
+                    cover_meta_template.add_css(page_css)
+                cover_html = cover_meta_template.html
             else:
                 orange("[SKIP] No HTML cover template found")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "notion-export-prettify"
-version = "1.3.0"
+version = "1.3.1"
 description = ""
 authors = ["Fabre Lambeau <fabre.lambeau@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
Check whether the page_css variable is populated before attempting to add the css

Fix fixes the following error when only a `cover.html` page is defined within a template folder.

```
[SKIP] No PDF background file found
[PROC] Rendering cover template
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/ben/brunyee-studio/tools/notion-export-prettify/notion_export_prettify/main.py", line 174, in main
    .add_css(page_css)
     ^^^^^^^^^^^^^^^^^
  File "/home/ben/brunyee-studio/tools/notion-export-prettify/notion_export_prettify/html_templator.py", line 17, in add_css
    new_style_tag.string = css
    ^^^^^^^^^^^^^^^^^^^^
  File "/home/ben/brunyee-studio/tools/notion-export-prettify/venv/lib/python3.11/site-packages/bs4/element.py", line 1414, in string
    self.append(string.__class__(string))
                ^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: NoneType takes no arguments
```